### PR TITLE
PR: 브라우저 라우팅 코드 추가

### DIFF
--- a/front/src/router/Path.ts
+++ b/front/src/router/Path.ts
@@ -1,0 +1,34 @@
+import Observable from "../models/Observable";
+
+class PathModel extends Observable {
+  private $pathName: string;
+
+  constructor() {
+    super();
+
+    const url = new URL(document.URL);
+    const pathName = url instanceof URL ? url.pathname : url;
+
+    this.$pathName = pathName;
+
+    window.addEventListener("popstate", () => {
+      const url = new URL(document.URL);
+      const pathName = url instanceof URL ? url.pathname : url;
+
+      this.changePath(pathName);
+    });
+  }
+
+  pushState(data: unknown, title: string, path: string) {
+    history.pushState(data, title, path);
+
+    this.changePath(path);
+  }
+
+  changePath(path: string) {
+    this.$pathName = path;
+    this.notify(this.$pathName);
+  }
+}
+
+export default new PathModel();

--- a/front/src/router/Router.ts
+++ b/front/src/router/Router.ts
@@ -1,0 +1,46 @@
+import Component from "../components/Component";
+
+class Route {
+  private $mappingTable: Map<string, Component>;
+  private $component: Component | null;
+  private $wrapper: HTMLElement;
+
+  constructor() {
+    this.$mappingTable = new Map<string, Component>();
+    this.$component = null;
+    this.$wrapper = document.createElement("section");
+  }
+
+  setComponent(path: string, component: Component) {
+    this.$mappingTable.set(path, component);
+  }
+
+  changeComponent(path: string) {
+    const targetComponent = this.$mappingTable.get(path);
+
+    if (!targetComponent) {
+      return;
+    }
+    this.$component = targetComponent;
+
+    this.render();
+  }
+
+  private render() {
+    if (!this.$component) {
+      return;
+    }
+
+    while (this.$wrapper.firstChild) {
+      this.$wrapper.removeChild(this.$wrapper.firstChild);
+    }
+
+    this.$wrapper.appendChild(this.$component.view);
+  }
+
+  getWrapper() {
+    return this.$wrapper;
+  }
+}
+
+export default new Route();


### PR DESCRIPTION
> Path에 해당하는 모델을 구독하는 router 컴포넌트 추가

### related issue

- #9 

### content

브라우저의 url (path) 를 model로 가지고 있고, 변경이 일어나는 경우 (history pushState를 하는 경우) model을 구독하고 있는 컴포넌트들에게 notify함

history popState의 경우 window객체에 event를 등록해 처리함
