### PR TITLE
PR: 내역 수정할 때 카테고리 라벨 이상하게 붙던 것 수정

### DIFF
--- a/back/src/daos/CategoryDAO.ts
+++ b/back/src/daos/CategoryDAO.ts
@@ -24,7 +24,7 @@ class CategoryDAO extends DAO {
         let outcomValue = 0;
         let value = 0;
         row.forEach((category: any) => {
-          const { content, is_income } = category;
+          const { id, content, is_income } = category;
           if (is_income === 1) {
             incomeValue++;
             value = incomeValue;
@@ -32,7 +32,7 @@ class CategoryDAO extends DAO {
             outcomValue++;
             value = outcomValue;
           }
-          categories.push(new Category(value, content, is_income));
+          categories.push(new Category(id, value, content, is_income));
         });
       }
       await connection.commit();

--- a/back/src/daos/dto/Category.ts
+++ b/back/src/daos/dto/Category.ts
@@ -1,9 +1,11 @@
 class Category {
+  id: number;
   value: number;
   content: string;
   income: boolean;
 
-  constructor(value: number, content: string, income: boolean) {
+  constructor(id: number, value: number, content: string, income: boolean) {
+    this.id = id;
     this.value = value;
     this.content = content;
     this.income = income;

--- a/front/src/components/History/InputForm.ts
+++ b/front/src/components/History/InputForm.ts
@@ -112,6 +112,9 @@ class InputForm extends Component {
   }
 
   resetInputs() {
+    // 분류 초기화
+    this.classificationModel.setClassifiacation("outcome");
+
     // 날짜 초기화
     this.dateModel.setDate(new Date(Date.now()));
 
@@ -177,7 +180,9 @@ class InputForm extends Component {
     const month = date.getMonth() + 1;
     const day = date.getDate();
     // 카테고리 가져오기
-    const category = this.selectedCategoryModel.getSelectedCategory().value;
+    const category = this.selectedCategoryModel
+      .getSelectedCategory()
+      .id!.toString();
 
     // 결제수단 가져오기
     const paymentMethod = this.selectedPaymentMethodModel.getSelectedPaymentMethod()
@@ -474,7 +479,13 @@ class InputForm extends Component {
             const idx = target.selectedIndex;
             const textContent = target[idx].textContent || "";
             const value = target[idx].getAttribute("value") || "";
+            const income = this.classificationModel.getClassification();
+            const id = this.categoryModel.getIdFromTextContent(
+              income,
+              textContent
+            );
             this.selectedCategoryModel.setSelectedCategory({
+              id,
               textContent,
               value,
             });

--- a/front/src/models/HistoryModel/InputForm/CategoryModel.ts
+++ b/front/src/models/HistoryModel/InputForm/CategoryModel.ts
@@ -4,6 +4,7 @@ import { SelectOption } from "../";
 import fetch from "../../../fetch";
 
 interface Category {
+  id: number;
   value: number;
   content: string;
   income: number;
@@ -14,8 +15,8 @@ class CategoryModel extends Observable {
 
   private categories: SelectOption[] = [];
   private classifiedCategories: {
-    income: { textContent: string; value: string }[];
-    outcome: { textContent: string; value: string }[];
+    income: { id: number; textContent: string; value: string }[];
+    outcome: { id: number; textContent: string; value: string }[];
   } = {
     income: [],
     outcome: [],
@@ -23,6 +24,13 @@ class CategoryModel extends Observable {
   private categoryTextContentValueMap: {
     income: Map<string, string>;
     outcome: Map<string, string>;
+  } = {
+    income: new Map(),
+    outcome: new Map(),
+  };
+  private categoryTextContentIdMap: {
+    income: Map<string, number>;
+    outcome: Map<string, number>;
   } = {
     income: new Map(),
     outcome: new Map(),
@@ -39,14 +47,19 @@ class CategoryModel extends Observable {
   init() {
     fetch.getCategories().then((categories) => {
       categories.forEach((category: Category) => {
-        const { value, content, income } = category;
+        const { id, value, content, income } = category;
         this.classifiedCategories[income === 1 ? "income" : "outcome"].push({
+          id,
           textContent: content,
           value: value.toString(),
         });
         this.categoryTextContentValueMap[
           income === 1 ? "income" : "outcome"
         ].set(content, value.toString());
+        this.categoryTextContentIdMap[income === 1 ? "income" : "outcome"].set(
+          content,
+          id
+        );
       });
 
       this.notify(this.categories);
@@ -55,6 +68,10 @@ class CategoryModel extends Observable {
 
   getValueFromTextContent(type: "income" | "outcome", textContent: string) {
     return this.categoryTextContentValueMap[type].get(textContent);
+  }
+
+  getIdFromTextContent(type: "income" | "outcome", textContent: string) {
+    return this.categoryTextContentIdMap[type].get(textContent);
   }
 
   initData() {

--- a/front/src/models/HistoryModel/InputForm/SelectedCategoryModel.ts
+++ b/front/src/models/HistoryModel/InputForm/SelectedCategoryModel.ts
@@ -2,7 +2,11 @@ import Observable from "../../Observable";
 import { SelectOption } from "../";
 
 class SelectedCategoryModel extends Observable {
-  private selectedCategory: SelectOption = { textContent: "", value: "" };
+  private selectedCategory: SelectOption = {
+    id: 0,
+    textContent: "",
+    value: "",
+  };
 
   constructor() {
     super();

--- a/front/src/models/HistoryModel/index.ts
+++ b/front/src/models/HistoryModel/index.ts
@@ -15,6 +15,7 @@ import PaymentMethodModel from "./InputForm/PaymentMethodModel";
 import SelectedPaymentMethodModel from "./InputForm/SelectedPaymentMethodModel";
 
 interface SelectOption {
+  id?: number;
   textContent: string;
   value: string;
   disabled?: boolean;


### PR DESCRIPTION
> 한줄요약
내역 수정할때 카테고리 id를 주어서 특정 카테고리로 바꿀 수 있도록함

### content
기존에는 프론트엔드에서 카테고리 id를 몰라서 index로 바꾸려다보니
지출, 수입에 각각 index가 있어서 index가 겹치는 것 때문에 엉뚱한 카테고리가 들어갔는데
백엔드에서 카테고리 id를 받아와서 사용하여 정확하게 수정이 가능하도록 만듦