### PR TITLE
PR: 막대형 그래프 제작

### DIFF
--- a/front/src/components/Statistics/StickGraph.scss
+++ b/front/src/components/Statistics/StickGraph.scss
@@ -1,0 +1,69 @@
+div.stick_graph {
+  width: 800px;
+}
+div.stick_graph hr:first-child {
+  border-top: 1px solid #000000;
+}
+
+div.stick_graph ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+div.stick_graph ul hr {
+  border-top: 1px solid #eeeeee;
+}
+
+div.stick_graph ul li {
+  display: flex;
+  height: 40px;
+  flex-direction: row;
+
+  justify-content: space-between;
+}
+
+div.stick_graph ul li div {
+  height: inherit;
+  padding: 0;
+
+  display: flex;
+
+  justify-content: center;
+  align-items: center;
+
+  text-align: center;
+  font-size: 1.2rem;
+}
+
+div.stick_graph ul li p {
+  margin: 0;
+}
+
+div.stick_graph ul li .category {
+  width: 250px;
+}
+
+div.stick_graph ul li .percent {
+  width: 200px;
+  color: var(--main-color);
+}
+
+div.stick_graph ul li .amount {
+  width: 200px;
+}
+
+div.stick_graph ul li div.graph {
+  width: 600px;
+  height: inherit;
+
+  display: flex;
+  justify-content: left;
+  align-items: center;
+}
+
+div.stick_graph ul li div.graph div.bar {
+  width: 0px;
+  height: 20px;
+  transition: width 2s ease;
+}

--- a/front/src/components/Statistics/StickGraph.ts
+++ b/front/src/components/Statistics/StickGraph.ts
@@ -1,0 +1,154 @@
+import Component from "../Component";
+
+import RootModel from "../../models/RootModel";
+import PieChartModel from "../../models/PieChartModel";
+
+import getCategoryOutcome, {
+  CategoryInfo,
+  ApiResponse,
+} from "../../fetch/getCategoryOutcome";
+
+import "./StickGraph.scss";
+
+type PieChartSize = {
+  width: number;
+  height: number;
+};
+
+type Color = {
+  R: number;
+  G: number;
+  B: number;
+};
+
+type Data = {
+  value: number;
+  title: string;
+};
+
+function makeColorCode(start: Color, diff: Color, index: number): string {
+  const R = Math.floor(start.R + diff.R * index).toString(16);
+  const G = Math.floor(start.G + diff.G * index).toString(16);
+  const B = Math.floor(start.B + diff.B * index).toString(16);
+
+  return `#${R}${G}${B}`;
+}
+
+export default class StickGraph extends Component {
+  private _size: PieChartSize;
+  private _startColor: Color;
+  private _endColor: Color;
+
+  private $ul: HTMLUListElement;
+
+  constructor(width: number, height: number) {
+    super();
+
+    this._size = {
+      width: width | 800,
+      height: height | 600,
+    };
+
+    this._startColor = {
+      R: 52,
+      G: 152,
+      B: 219,
+    };
+
+    this._endColor = {
+      R: 210,
+      G: 180,
+      B: 222,
+    };
+
+    this.view = document.createElement("div");
+    this.view.className = "stick_graph";
+
+    const mainHr = document.createElement("hr");
+    mainHr.className = "main_line";
+    this.$ul = document.createElement("ul");
+
+    this.view.appendChild(mainHr);
+    this.view.appendChild(this.$ul);
+
+    PieChartModel.subscribe("changeStickData", (data: CategoryInfo[]) => {
+      this.setView(data);
+    });
+
+    this.fetching();
+  }
+
+  fetching(): void {
+    const year = RootModel.getYear();
+    const month = RootModel.getMonth();
+
+    getCategoryOutcome(year, month).then((response: ApiResponse) => {
+      if (response.success) {
+        this.setView(response.data);
+      } else {
+        this.setView([
+          {
+            title: "empty data",
+            value: 1,
+          },
+        ]);
+      }
+    });
+  }
+
+  setView(data: Data[]): void {
+    const total = data.reduce((pre, cur) => {
+      return pre + cur.value;
+    }, 0);
+
+    const diff = {
+      R: (this._endColor.R - this._startColor.R) / data.length,
+      G: (this._endColor.G - this._startColor.G) / data.length,
+      B: (this._endColor.B - this._startColor.B) / data.length,
+    };
+
+    const arr: string[] = [];
+
+    data.forEach((cur, index) => {
+      const color = makeColorCode(this._startColor, diff, index);
+      const percent = (cur.value / total) * 100;
+      const content = /* html */ `<li>
+<div class="category">
+  <p>${cur.title}</p>
+</div>
+<div class="percent">
+  <p>${percent.toFixed(2)}%</p>
+</div>
+<div class="graph">
+  <div class="bar" data-percent=${percent} style="background-color: ${color};"></div>
+</div>
+<div class="amount">
+  <p>${cur.value.toLocaleString()}원</p>
+</div>
+</li>`;
+
+      arr.push(content);
+    });
+
+    this.$ul.innerHTML = arr.join("\n<hr />\n");
+
+    const graph: HTMLDivElement =
+      this.$ul.querySelector("div.graph") || document.createElement("div");
+    const barWidth = graph.offsetWidth;
+
+    const arrBar: NodeListOf<HTMLDivElement> = this.$ul.querySelectorAll(
+      "div.bar"
+    );
+
+    Array.from(arrBar).forEach((stick, index) => {
+      setTimeout(() => {
+        const percent = Number(stick.dataset.percent);
+        stick.style.width = `${(percent / 100) * barWidth}px`;
+      }, (1000 / data.length) * index);
+    });
+  }
+
+  reRender(): void {
+    this.fetching();
+  }
+}

--- a/front/src/components/Statistics/index.ts
+++ b/front/src/components/Statistics/index.ts
@@ -1,6 +1,7 @@
 import Component from "../Component";
 import LineGraph from "./LineGraph";
 import PieChart from "./PieChart";
+import StickGraph from "./StickGraph";
 import Checkboxes from "./CheckBoxes";
 
 import StatisticsPageModel, { CASE } from "../../models/StatisticsPageModel";
@@ -8,6 +9,7 @@ import StatisticsPageModel, { CASE } from "../../models/StatisticsPageModel";
 export default class Statistics extends Component {
   $lineGraph: LineGraph;
   $pieChart: PieChart;
+  $stickGraph: StickGraph;
   $checkboxes: Checkboxes;
 
   constructor() {
@@ -15,6 +17,7 @@ export default class Statistics extends Component {
 
     this.$lineGraph = new LineGraph(800, 600);
     this.$pieChart = new PieChart(800, 600);
+    this.$stickGraph = new StickGraph(800, 600);
     this.$checkboxes = new Checkboxes();
 
     this.view = document.createElement("div");
@@ -28,6 +31,7 @@ export default class Statistics extends Component {
       }
       case CASE.PIE: {
         this.view.appendChild(this.$pieChart.view);
+        this.view.appendChild(this.$stickGraph.view);
         break;
       }
     }
@@ -36,6 +40,7 @@ export default class Statistics extends Component {
       switch (data) {
         case CASE.LINE: {
           this.view.removeChild(this.$pieChart.view);
+          this.view.removeChild(this.$stickGraph.view);
           this.view.appendChild(this.$lineGraph.view);
           this.$lineGraph.reRender();
           break;
@@ -43,7 +48,11 @@ export default class Statistics extends Component {
         case CASE.PIE: {
           this.view.removeChild(this.$lineGraph.view);
           this.view.appendChild(this.$pieChart.view);
+          this.view.appendChild(this.$stickGraph.view);
+
           this.$pieChart.reRender();
+          this.$stickGraph.reRender();
+
           break;
         }
       }


### PR DESCRIPTION
> 막대형 그래프를 제작함

### related issue

- #49 

### content

![stick](https://user-images.githubusercontent.com/38618187/89415326-abf7c800-d766-11ea-9def-4d8b5dd00f85.gif)

빠른 제작을 위해 svg가 아닌 div와 width를 이용함

이전에 제작한 PieChart에서 사용하는 Model과 동일한 Model을 사용함

색상을 구하는 코드, percentage를 구하는 코드 등 중복되는 부분이 많음

transition과 width값의 변경을 통해 그래프의 애니메이션을 구현함

이 방법을 사용할 경우, 100%일 때의 그래프의 최대 길이를 파악해야 하므로 이 때는 querySelector로 막대 그래프가 채워질 수 있는 공간 태그를 찾아 offsetWidth 값으로 계산함
