### PR TITLE
PR: 통계 페이지 컴포넌트의 뷰에서 fetching 제거

### DIFF
--- a/front/src/components/Statistics/LineGraph.scss
+++ b/front/src/components/Statistics/LineGraph.scss
@@ -2,36 +2,42 @@ body {
   font-family: "Open Sans", sans-serif;
 }
 
-.graph .average,
-.graph .labels {
+.line-graph .error {
+  height: 300px;
+  display: flex;
+  align-items: center;
+}
+
+.line-graph .graph .average,
+.line-graph .graph .labels {
   dominant-baseline: central;
 }
 
-.graph .labels.x-labels {
+.line-graph .graph .labels.x-labels {
   text-anchor: middle;
 }
 
-.graph .labels.y-labels {
+.line-graph .graph .labels.y-labels {
   text-anchor: end;
 }
 
-.graph {
+.line-graph .graph {
   padding: 50px;
 }
 
-.graph .grid {
+.line-graph .graph .grid {
   stroke: #ccc;
   stroke-dasharray: 0;
   stroke-width: 1;
 }
 
-.graph g polyline {
+.line-graph .graph g polyline {
   fill: none;
   stroke: var(--main-color);
   stroke-width: 3;
 }
 
-.graph circle {
+.line-graph .graph circle {
   fill: #ffffff;
   stroke: var(--main-color);
   stroke-width: 3px;

--- a/front/src/components/Statistics/LineGraph.ts
+++ b/front/src/components/Statistics/LineGraph.ts
@@ -1,8 +1,7 @@
 import Component from "../Component";
 import LineGraphModel from "../../models/LineGraphModel";
-import RootModel from "../../models/RootModel";
 
-import getDailyOutcomes, { DataType } from "../../fetch/getDailyOutcomes";
+import { DataType } from "../../fetch/getDailyOutcomes";
 import {
   getStandards,
   createAverageLine,
@@ -30,25 +29,20 @@ export default class LineGraph extends Component {
     };
 
     this.view = document.createElement("div");
+    this.view.className = "line-graph";
 
     LineGraphModel.subscribe("changeLineGraph", async (data: DataType) => {
       this.setView(data);
     });
-
-    this.fetching();
-  }
-
-  fetching(): void {
-    getDailyOutcomes(RootModel.getYear(), RootModel.getMonth()).then(
-      (response) => {
-        if (response.success) {
-          this.setView(response.data);
-        }
-      }
-    );
   }
 
   setView(data: DataType): void {
+    if (data.dates.length === 0) {
+      const error = /* html */ `<div class="error"><h1>데이터를 받아오지 못했습니다</h1></div>`;
+      this.view.innerHTML = error;
+      return;
+    }
+
     const { array, average } = getStandards(data.dates);
     const first = array[0];
     const last = array[array.length - 1];
@@ -75,10 +69,5 @@ ${createDots(data.dates, first, last, this._size).join("\n")}
 </svg>
 `;
     this.view.innerHTML = content;
-  }
-
-  reRender(): void {
-    const before = this.view.innerHTML;
-    this.view.innerHTML = before;
   }
 }

--- a/front/src/components/Statistics/PieChart.ts
+++ b/front/src/components/Statistics/PieChart.ts
@@ -70,6 +70,11 @@ export default class PieChart extends Component {
   }
 
   setView(data: Data[]): void {
+    // SAFE GUARD!!
+    if (data.length === 0) {
+      return;
+    }
+
     const r = this.r;
     const cx = this.cx;
     const cy = this.cy;

--- a/front/src/components/Statistics/PieChart.ts
+++ b/front/src/components/Statistics/PieChart.ts
@@ -1,12 +1,8 @@
 import Component from "../Component";
 
-import RootModel from "../../models/RootModel";
 import PieChartModel from "../../models/PieChartModel";
 
-import getCategoryOutcome, {
-  CategoryInfo,
-  ApiResponse,
-} from "../../fetch/getCategoryOutcome";
+import { CategoryInfo } from "../../fetch/getCategoryOutcome";
 
 import "./PieChart.scss";
 
@@ -71,26 +67,6 @@ export default class PieChart extends Component {
     PieChartModel.subscribe("changeData", (data: CategoryInfo[]) => {
       this.setView(data);
     });
-
-    this.fetching();
-  }
-
-  fetching(): void {
-    const year = RootModel.getYear();
-    const month = RootModel.getMonth();
-
-    getCategoryOutcome(year, month).then((response: ApiResponse) => {
-      if (response.success) {
-        this.setView(response.data);
-      } else {
-        this.setView([
-          {
-            title: "empty data",
-            value: 1,
-          },
-        ]);
-      }
-    });
   }
 
   setView(data: Data[]): void {
@@ -150,10 +126,11 @@ export default class PieChart extends Component {
   `;
       arr.push(circle);
     });
-    // svg.innerHTML += arr.reverse().join("\n");
 
     const content = `
-    <svg viewbox="0 0 100 100" class="pie" width="800" height="600">
+    <svg viewbox="0 0 100 100" class="pie" width="${
+      this._size.width
+    }" height="${this._size.height}">
       ${arr.reverse().join("\n")}
     </svg>`;
 
@@ -188,9 +165,5 @@ export default class PieChart extends Component {
           text.style.opacity = `${1}`;
         }, 100 + 200 + index * 100);
       });
-  }
-
-  reRender(): void {
-    this.fetching();
   }
 }

--- a/front/src/components/Statistics/StickGraph.scss
+++ b/front/src/components/Statistics/StickGraph.scss
@@ -41,7 +41,7 @@ div.stick_graph ul li p {
 }
 
 div.stick_graph ul li .category {
-  width: 250px;
+  width: 200px;
 }
 
 div.stick_graph ul li .percent {
@@ -54,7 +54,7 @@ div.stick_graph ul li .amount {
 }
 
 div.stick_graph ul li div.graph {
-  width: 600px;
+  width: 400px;
   height: inherit;
 
   display: flex;

--- a/front/src/components/Statistics/StickGraph.ts
+++ b/front/src/components/Statistics/StickGraph.ts
@@ -1,12 +1,8 @@
 import Component from "../Component";
 
-import RootModel from "../../models/RootModel";
 import PieChartModel from "../../models/PieChartModel";
 
-import getCategoryOutcome, {
-  CategoryInfo,
-  ApiResponse,
-} from "../../fetch/getCategoryOutcome";
+import { CategoryInfo } from "../../fetch/getCategoryOutcome";
 
 import "./StickGraph.scss";
 
@@ -74,41 +70,24 @@ export default class StickGraph extends Component {
     PieChartModel.subscribe("changeStickData", (data: CategoryInfo[]) => {
       this.setView(data);
     });
-
-    this.fetching();
-  }
-
-  fetching(): void {
-    const year = RootModel.getYear();
-    const month = RootModel.getMonth();
-
-    getCategoryOutcome(year, month).then((response: ApiResponse) => {
-      if (response.success) {
-        this.setView(response.data);
-      } else {
-        this.setView([
-          {
-            title: "empty data",
-            value: 1,
-          },
-        ]);
-      }
-    });
   }
 
   setView(data: Data[]): void {
+    if (data.length === 0) {
+      return;
+    }
+
     const total = data.reduce((pre, cur) => {
       return pre + cur.value;
     }, 0);
-
     const diff = {
       R: (this._endColor.R - this._startColor.R) / data.length,
       G: (this._endColor.G - this._startColor.G) / data.length,
       B: (this._endColor.B - this._startColor.B) / data.length,
     };
+    const barWidth = this._size.width * 0.6;
 
     const arr: string[] = [];
-
     data.forEach((cur, index) => {
       const color = makeColorCode(this._startColor, diff, index);
       const percent = (cur.value / total) * 100;
@@ -132,10 +111,6 @@ export default class StickGraph extends Component {
 
     this.$ul.innerHTML = arr.join("\n<hr />\n");
 
-    const graph: HTMLDivElement =
-      this.$ul.querySelector("div.graph") || document.createElement("div");
-    const barWidth = graph.offsetWidth;
-
     const arrBar: NodeListOf<HTMLDivElement> = this.$ul.querySelectorAll(
       "div.bar"
     );
@@ -146,9 +121,5 @@ export default class StickGraph extends Component {
         stick.style.width = `${(percent / 100) * barWidth}px`;
       }, (1000 / data.length) * index);
     });
-  }
-
-  reRender(): void {
-    this.fetching();
   }
 }

--- a/front/src/components/Statistics/StickGraph.ts
+++ b/front/src/components/Statistics/StickGraph.ts
@@ -73,6 +73,7 @@ export default class StickGraph extends Component {
   }
 
   setView(data: Data[]): void {
+    // SAFE GUARD!!
     if (data.length === 0) {
       return;
     }

--- a/front/src/components/Statistics/index.ts
+++ b/front/src/components/Statistics/index.ts
@@ -5,6 +5,7 @@ import StickGraph from "./StickGraph";
 import Checkboxes from "./CheckBoxes";
 
 import StatisticsPageModel, { CASE } from "../../models/StatisticsPageModel";
+import PieChartModel from "../../models/PieChartModel";
 
 export default class Statistics extends Component {
   $lineGraph: LineGraph;
@@ -42,6 +43,7 @@ export default class Statistics extends Component {
           this.view.removeChild(this.$pieChart.view);
           this.view.removeChild(this.$stickGraph.view);
           this.view.appendChild(this.$lineGraph.view);
+
           this.$lineGraph.reRender();
           break;
         }
@@ -50,9 +52,7 @@ export default class Statistics extends Component {
           this.view.appendChild(this.$pieChart.view);
           this.view.appendChild(this.$stickGraph.view);
 
-          this.$pieChart.reRender();
-          this.$stickGraph.reRender();
-
+          PieChartModel.customNotify();
           break;
         }
       }
@@ -60,8 +60,15 @@ export default class Statistics extends Component {
   }
 
   reRender(): void {
-    this.$lineGraph.reRender();
-    this.$pieChart.reRender();
-    this.$stickGraph.reRender();
+    switch (StatisticsPageModel.getCase()) {
+      case CASE.LINE: {
+        this.$lineGraph.reRender();
+        break;
+      }
+      case CASE.PIE: {
+        PieChartModel.customNotify();
+        break;
+      }
+    }
   }
 }

--- a/front/src/components/Statistics/index.ts
+++ b/front/src/components/Statistics/index.ts
@@ -6,6 +6,7 @@ import Checkboxes from "./CheckBoxes";
 
 import StatisticsPageModel, { CASE } from "../../models/StatisticsPageModel";
 import PieChartModel from "../../models/PieChartModel";
+import LineGraphModel from "../../models/LineGraphModel";
 
 export default class Statistics extends Component {
   $lineGraph: LineGraph;
@@ -44,7 +45,7 @@ export default class Statistics extends Component {
           this.view.removeChild(this.$stickGraph.view);
           this.view.appendChild(this.$lineGraph.view);
 
-          this.$lineGraph.reRender();
+          LineGraphModel.customNotify();
           break;
         }
         case CASE.PIE: {
@@ -62,7 +63,7 @@ export default class Statistics extends Component {
   reRender(): void {
     switch (StatisticsPageModel.getCase()) {
       case CASE.LINE: {
-        this.$lineGraph.reRender();
+        LineGraphModel.customNotify();
         break;
       }
       case CASE.PIE: {

--- a/front/src/components/Statistics/index.ts
+++ b/front/src/components/Statistics/index.ts
@@ -62,5 +62,6 @@ export default class Statistics extends Component {
   reRender(): void {
     this.$lineGraph.reRender();
     this.$pieChart.reRender();
+    this.$stickGraph.reRender();
   }
 }

--- a/front/src/models/LineGraphModel.ts
+++ b/front/src/models/LineGraphModel.ts
@@ -22,10 +22,32 @@ class CalendarModel extends Observable {
       const response = await getDailyOutcomes(data.year, data.month);
       if (response.success) {
         this.dateData.dates = response.data.dates;
+        this.notify(this.dateData);
+      } else {
+        this.dateData.dates = [];
+        this.notify(this.dateData);
       }
-
-      this.notify(this.dateData);
     });
+
+    this.setData();
+  }
+
+  setData() {
+    getDailyOutcomes(this.dateData.year, this.dateData.month).then(
+      (response) => {
+        if (response.success) {
+          this.dateData.dates = response.data.dates;
+          this.notify(this.dateData);
+        } else {
+          this.dateData.dates = [];
+          this.notify(this.dateData);
+        }
+      }
+    );
+  }
+
+  customNotify() {
+    this.notify(this.dateData);
   }
 }
 

--- a/front/src/models/PieChartModel.ts
+++ b/front/src/models/PieChartModel.ts
@@ -19,6 +19,25 @@ class PieChartModel extends Observable {
 
       this.notify(this.pieData);
     });
+
+    this.setData();
+  }
+
+  setData() {
+    const year = RootModel.getYear();
+    const month = RootModel.getMonth();
+
+    getCategoryOutcome(year, month).then((response) => {
+      if (response.success) {
+        this.pieData = response.data;
+      }
+
+      this.notify(this.pieData);
+    });
+  }
+
+  customNotify() {
+    this.notify(this.pieData);
   }
 }
 


### PR DESCRIPTION
> 통계 페이지 컴포넌트들의 view에서 fetch로 데이터를 받아오던 부분 삭제

### content

페이지 이동 시 막대그래프가 표시되지 않던 오류를 수정하며 개선한 작업

View에서 fetching을 날리지 않고, Model에서 fetching을 날리도록 수정함

이는 모델과 뷰를 분리하기 위해서 이며, model 이 변경되었을 때 view는 모델에서 받아온 내역을 받아서 사용하기 위함