### PR TITLE
fix: 자잘한 내역 수정

### DIFF
--- a/front/src/components/History/History.ts
+++ b/front/src/components/History/History.ts
@@ -9,6 +9,7 @@ import {
   HistoryListModel,
   HistoryDataType,
 } from "../../models/HistoryModel";
+import Path from "../../router/Path";
 import "./History.scss";
 
 class History extends Component {
@@ -56,6 +57,11 @@ class History extends Component {
   }
 
   subscribeModels() {
+    Path.subscribe("subPathInHistory", (pathName: string) => {
+      CheckboxModel.setIsIncomeChecked(true);
+      CheckboxModel.setIsOutcomeChecked(true);
+    });
+
     this.checkboxModel.subscribe(
       "subCheckboxInHistory",
       (isChecked: TypeCheckbox) => {

--- a/front/src/components/History/InputForm.ts
+++ b/front/src/components/History/InputForm.ts
@@ -113,6 +113,11 @@ class InputForm extends Component {
   }
 
   resetInputs() {
+    // 확인버튼을 위한 유효성 검사 초기화
+    this.validationMap.forEach((_, key) => {
+      this.validationMap.set(key, false);
+    });
+
     // 분류 초기화
     this.classificationModel.setClassifiacation("outcome");
 
@@ -130,11 +135,6 @@ class InputForm extends Component {
 
     // 내용 초기화
     (<HTMLInputElement>this.inputDetail?.view).value = "";
-
-    // 확인버튼을 위한 유효성 검사 초기화
-    this.validationMap.forEach((_, key) => {
-      this.validationMap.set(key, false);
-    });
 
     this.editFlagModel.setEditMode(false);
     this.checkAllInputsValidation();

--- a/front/src/models/HistoryModel/Checkbox/CheckboxModel.ts
+++ b/front/src/models/HistoryModel/Checkbox/CheckboxModel.ts
@@ -16,12 +16,12 @@ class Checkbox extends Observable {
   }
 
   setIsIncomeChecked(check: boolean) {
-    this.isChecked.income = check;
+    this.isChecked = { ...this.isChecked, income: check };
     this.notify(this.isChecked);
   }
 
   setIsOutcomeChecked(check: boolean) {
-    this.isChecked.outcome = check;
+    this.isChecked = { ...this.isChecked, outcome: check };
     this.notify(this.isChecked);
   }
 


### PR DESCRIPTION
> 한줄요약
자잘한 내역 수정

### related issue

- #46 

### content
내역에서 입력 완료 후 dateModel값 오늘로 다시 세팅해줌-> 다시 입력할때 유효성 검사를 통과하기 위함
라우트 변경됐을 때 내역페이지 수입, 지출 체크상태로 만듦
